### PR TITLE
documented no support for AWS IAM Instance roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ task deploy(type: S3Sync){
     <tr>
         <td><b>* accessKey()</b></td>
         <td>AWS Access Key</td>
-        <td>-</td>
+        <td>The accessKey and secretKey msut be set - the plugin does not support AWS IAM Instance roles.</td>
     </tr>
     <tr>
         <td><b>* secretKey()</b></td>


### PR DESCRIPTION
Added some doco so people know that AWS IAM Instance roles are not supported.
Many people don't care about that - but many advanced AWS users will just assume EC2 roles would be supported (I did).